### PR TITLE
Automatic release on tag push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
             /*assets/tcneiadditions/*
             /*assets/thaumcraft/*
       - name: Generate Changelog
+        id: changelog
         uses: requarks/changelog-action@v1.10.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a GitHub workflow to automatically create a release archive on tag push and creates a release accordingly.

The archiving excludes all files and folders listed in the workflow file. Those include:
- currently non-textured mods 
- psd folders and *.psd files
- designHelp folder
- .git files and folders

In addition a changelog is automatically generated, listing commits between the last release.
Might later be turned off if changelogs want to manually be created. This needs `omitBody` of `release-action` set to `true`, in order to not overwrite it.
